### PR TITLE
grains.filter_by os instead of os_family

### DIFF
--- a/node/map.jinja
+++ b/node/map.jinja
@@ -21,4 +21,4 @@
         'node_pkg': 'nodejs',
         'npm_pkg': 'nodejs' if pillar_get('node:install_from_ppa') else 'npm',
     },
-}, merge=pillar_get('node:lookup')) %}
+}, grain='os', merge=pillar_get('node:lookup')) %}

--- a/node/pkg.sls
+++ b/node/pkg.sls
@@ -1,5 +1,17 @@
 {%- from "node/map.jinja" import node, npm_bin with context %}
 
+{%- if grains['os'] == 'Ubuntu' and salt['pillar.get']('node:install_from_ppa') %}
+nodejs.ppa:
+  pkgrepo.managed:
+    - humanname: node.js PPA
+    - name: deb http://ppa.launchpad.net/chris-lea/node.js/ubuntu precise main
+    - dist: precise
+    - file: /etc/apt/sources.list.d/nodejs.list
+    - keyid: "C7917B12"
+    - keyserver: keyserver.ubuntu.com
+    - require_in:
+      pkg: nodejs
+{%- else %}
 npm:
 {%- if grains['os'] == 'Debian' and grains['osrelease']|float < 8 %}
   file.exists:
@@ -13,18 +25,6 @@ npm:
     - require:
       - pkg: nodejs
 {%- endif %}
-
-{%- if grains['os'] == 'Ubuntu' and salt['pillar.get']('node:install_from_ppa') %}
-nodejs.ppa:
-  pkgrepo.managed:
-    - humanname: node.js PPA
-    - name: deb http://ppa.launchpad.net/chris-lea/node.js/ubuntu precise main
-    - dist: precise
-    - file: /etc/apt/sources.list.d/nodejs.list
-    - keyid: "C7917B12"
-    - keyserver: keyserver.ubuntu.com
-    - require_in:
-      pkg: nodejs
 {%- endif %}
 nodejs:
   pkg.installed:

--- a/node/pkg.sls
+++ b/node/pkg.sls
@@ -4,8 +4,8 @@
 nodejs.ppa:
   pkgrepo.managed:
     - humanname: node.js PPA
-    - name: deb http://ppa.launchpad.net/chris-lea/node.js/ubuntu precise main
-    - dist: precise
+    - name: deb http://ppa.launchpad.net/chris-lea/node.js/ubuntu {{ grains['oscodename'] }} main
+    - dist: {{ grains['oscodename'] }}
     - file: /etc/apt/sources.list.d/nodejs.list
     - keyid: "C7917B12"
     - keyserver: keyserver.ubuntu.com


### PR DESCRIPTION
os_family is the default grain for grains.filter_by, and is 'Debian' for both Debian and Ubuntu. Filtering by the os grain fixes detection for installing the correct packages on Ubuntu.

```
$ salt '*' grains.item os_family
webserver-iad-dev-01:
    ----------
    os_family:
        Debian

$ salt '*' grains.item os
webserver-iad-dev-01:
    ----------
    os:
        Ubuntu
```