### PR TITLE
Require apt-transport-https since we're using an HTTPS ppa.

### DIFF
--- a/node/pkg.sls
+++ b/node/pkg.sls
@@ -2,6 +2,10 @@
 
 {%- if grains['os'] == 'Ubuntu' and salt['pillar.get']('node:install_from_ppa') %}
 nodejs.ppa:
+  pkg.installed:
+    - name: apt-transport-https
+    - require_in:
+      - pkgrepo: nodejs.ppa
   pkgrepo.managed:
     - humanname: NodeSource Node.js Repository
     - name: deb https://deb.nodesource.com/node_0.12 {{ grains['oscodename'] }} main


### PR DESCRIPTION
The ubuntu trusty Docker container does not come with apt-transport-https by default. This ensures it's there.