### PR TITLE
Node.js v4.x support

### DIFF
--- a/node/pkg.sls
+++ b/node/pkg.sls
@@ -8,7 +8,7 @@ nodejs.ppa:
       - pkgrepo: nodejs.ppa
   pkgrepo.managed:
     - humanname: NodeSource Node.js Repository
-    - name: deb https://deb.nodesource.com/node_0.12 {{ grains['oscodename'] }} main
+    - name: deb {{ salt['pillar.get']('node:ppa:repository_url', 'https://deb.nodesource.com/node_0.12') }} {{ grains['oscodename'] }} main
     - dist: {{ grains['oscodename'] }}
     - file: /etc/apt/sources.list.d/nodesource.list
     - keyid: "68576280"


### PR DESCRIPTION
add the ability to specify the PPA repository, making it possible to install the latest 4.x versions from `https://deb.nodesource.com/node_4.x` by providing the necessary pillar data