### PR TITLE
Add npmrc template support

### DIFF
--- a/node/config.sls
+++ b/node/config.sls
@@ -1,0 +1,13 @@
+{% from "node/map.jinja" import npmrc with context %}
+{% set config = salt['pillar.get']('npm:config') %}
+{% if config %}
+{{ npmrc }}:
+  file.managed:
+    - source: salt://node/files/npmrc.jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - context:
+        config: {{ config|json() }}
+{% endif %}

--- a/node/files/npmrc.jinja
+++ b/node/files/npmrc.jinja
@@ -1,0 +1,3 @@
+{% for key, value in config.items() %}
+{{ key }} = {{ value }}
+{% endfor %}

--- a/node/init.sls
+++ b/node/init.sls
@@ -5,3 +5,4 @@ include:
 {%- else %}
   - .pkg
 {%- endif %}
+  - .config

--- a/node/map.jinja
+++ b/node/map.jinja
@@ -1,8 +1,20 @@
 {% set pillar_get = salt['pillar.get'] -%}
 
-{% set npm_prefix = pillar_get('npm:prefix', '/usr/local') %}
+{% if pillar_get('node:install_from_source') %}
+{% set default_npm_prefix = '/usr/local' %}
+{% else %}
+{% set default_npm_prefix = '/usr' %}
+{% endif %}
+{% set npm_prefix = pillar_get('npm:prefix', default_npm_prefix) %}
 {% set npm_bin = '{0}/bin/npm'.format(npm_prefix) %}
 {% set npm_src_requirement = 'file: {0}'.format(npm_bin) %}
+
+{% if npm_prefix == '/usr' %}
+{% set npmrc_prefix = '' %}
+{% else %}
+{% set npmrc_prefix = npm_prefix %}
+{% endif %}
+{% set npmrc = '{0}/etc/npmrc'.format(npmrc_prefix) %}
 
 {% set npm_requirement = 'pkg: npm' %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -5,3 +5,6 @@ node:
   # install_from_ppa: True
   # ppa:
   #   repository_url: https://deb.nodesource.com/node_4.x
+npm:
+  config:
+    prefix: /opt/node


### PR DESCRIPTION
Allows salt to manage the global [npmrc](https://docs.npmjs.com/files/npmrc).