### PR TITLE
Add install_from_binary to install node.js from the binary distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,24 @@ This formula installs [node.js](https://nodejs.org/en/).
 An example pillar file looks as follows:
 
     node:
-      version: 5.1.0
-      checksum: 25b2d3b7dd57fe47a483539fea240a3c6bbbdab4d89a45a812134cf1380ecb94
+      version: 5.4.0
+      checksum: 1dfe37a00cf0ed62beb73071f571ac56697f544a98cc2ff3318faec6363d72ab
       make_jobs: 2
+      install_from_source: True
 
 Available versions can be found on [nodejs.org/dist/](https://nodejs.org/dist/); the checksums are listed in the
-file `SHASUMS256.txt` in the respective version’s directory.
+file `SHASUMS256.txt` in the respective version’s directory. The *node-v….tar.gz* checksum is used.
+
+## Installing binary packages
+
+On Linux, the binary node.js distribution can be installed to `/usr/local/share/` with the following pillar file:
+
+    node:
+      version: 5.4.0
+      checksum: f037e2734f52b9de63e6d4a4e80756477b843e6f106e0be05591a16b71ec2bd0
+      install_from_binary: True
+
+The checksum for the *node-v…-linux-x64.tar.gz* file has to be provided.
 
 ### Older versions
 

--- a/node/binary.sls
+++ b/node/binary.sls
@@ -1,0 +1,23 @@
+{% set node = pillar.get('node', {}) -%}
+{% set version = node.get('version', '5.4.0') -%}
+{% set checksum = node.get('checksum', 'f037e2734f52b9de63e6d4a4e80756477b843e6f106e0be05591a16b71ec2bd0') -%}
+{% set pkgname = 'node-v' ~ version ~ '-linux-x64' -%}
+
+Get binary package:
+  file.managed:
+    - name: /usr/local/src/{{ pkgname }}.tar.gz
+    - source: https://nodejs.org/dist/v{{ version }}/{{ pkgname }}.tar.gz
+    - source_hash: sha256={{ checksum }}
+
+Extract binary package:
+  archive.extracted:
+    - name: /usr/local/src/
+    - source: /usr/local/src/{{ pkgname }}.tar.gz
+    - archive_format: tar
+    - if_missing: /usr/local/src/{{ pkgname }}
+
+Copy lib:
+  cmd.run:
+    - cwd: /usr/local/src/{{ pkgname }}/
+    - name: cp -r bin/ include/ lib/ share/ /usr/local/
+    - unless: cmp /usr/local/bin/node /usr/local/src/{{ pkgname }}/bin/node

--- a/node/init.sls
+++ b/node/init.sls
@@ -2,6 +2,8 @@
 include:
 {%- if pillar_get('node:install_from_source') %}
   - .source
+{%- elif pillar_get('node:install_from_binary') %}
+  - .binary
 {%- else %}
   - .pkg
 {%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,19 @@
+# Install from source:
 node:
-  version: 5.1.0
-  checksum: 25b2d3b7dd57fe47a483539fea240a3c6bbbdab4d89a45a812134cf1380ecb94
+  version: 5.4.0
+  install_from_source: True
+  checksum: 1dfe37a00cf0ed62beb73071f571ac56697f544a98cc2ff3318faec6363d72ab
   make_jobs: 2
-  # install_from_ppa: True
-  # ppa:
-  #   repository_url: https://deb.nodesource.com/node_4.x
+
+# Install from binary:
+node:
+  version: 5.4.0
+  install_from_binary: True
+  checksum: f037e2734f52b9de63e6d4a4e80756477b843e6f106e0be05591a16b71ec2bd0
+
+# Install from PPA:
+node:
+  version: 5.4.0
+  install_from_ppa: True
+  ppa:
+    repository_url: https://deb.nodesource.com/node_5.x


### PR DESCRIPTION
This pull request adds the option to install node.js from the binary distribution instead of compiling it from source. Depending on the machine, this is way faster (some take 30+ minutes for installation).