### PR TITLE
Fix a bug with improperly used archive.extracted source value

### DIFF
--- a/node/binary.sls
+++ b/node/binary.sls
@@ -3,16 +3,11 @@
 {% set checksum = node.get('checksum', 'f037e2734f52b9de63e6d4a4e80756477b843e6f106e0be05591a16b71ec2bd0') -%}
 {% set pkgname = 'node-v' ~ version ~ '-linux-x64' -%}
 
-Get binary package:
-  file.managed:
-    - name: /usr/local/src/{{ pkgname }}.tar.gz
-    - source: https://nodejs.org/dist/v{{ version }}/{{ pkgname }}.tar.gz
-    - source_hash: sha256={{ checksum }}
-
 Extract binary package:
   archive.extracted:
     - name: /usr/local/src/
-    - source: /usr/local/src/{{ pkgname }}.tar.gz
+    - source: https://nodejs.org/dist/v{{ version }}/{{ pkgname }}.tar.gz
+    - source_hash: sha256={{ checksum }}
     - archive_format: tar
     - if_missing: /usr/local/src/{{ pkgname }}
 


### PR DESCRIPTION
saltstack-formulas/node-formula#25