### PR TITLE
Allow package pinning when using package repo

### DIFF
--- a/node/pkg.sls
+++ b/node/pkg.sls
@@ -22,5 +22,5 @@ nodejs:
     - name: {{ node.node_pkg }}
     - reload_modules: true
 {%- if salt['pillar.get']('node:version') %}
-    - version: {{ node.version }}
+    - version: {{ salt['pillar.get']('node:version') }}
 {%- endif %}

--- a/node/pkg.sls
+++ b/node/pkg.sls
@@ -21,3 +21,6 @@ nodejs:
   pkg.installed:
     - name: {{ node.node_pkg }}
     - reload_modules: true
+{%- if salt['pillar.get']('node:version') %}
+    - version: {{ node.version }}
+{%- endif %}


### PR DESCRIPTION
I added the option to use the specified version from the pillar to install instead of just installing once and never doing anything about it again. If you leave version out of your pillar, the old behaviour is still used as it's put in a nice if block.