### PR TITLE
Correct packages and fpm as checkinstall alternative for RedHat and CentOS

### DIFF
--- a/node/map.jinja
+++ b/node/map.jinja
@@ -31,7 +31,7 @@
     },
 }, grain='os', merge=pillar_get('node:lookup')) %}
 
-{% if pillar_get('node:install_from_source') or (grains['os'] == 'Debian' and grains['osrelease']|float < 8 and not pillar_get('node:install_from_ppa')) %}
+{% if pillar_get('node:install_from_source') or (grains['os_family'] == 'Debian' and grains['osrelease']|float < 8 and not pillar_get('node:install_from_ppa')) %}
   {% set npm_requirement = npm_src_requirement %}
 {% else %}
   {% set npm_requirement = 'pkg: {0}'.format(node['npm_pkg']) %}

--- a/node/map.jinja
+++ b/node/map.jinja
@@ -1,18 +1,18 @@
 {% set pillar_get = salt['pillar.get'] -%}
 
 {% if pillar_get('node:install_from_source') %}
-{% set default_npm_prefix = '/usr/local' %}
+  {% set default_npm_prefix = '/usr/local' %}
 {% else %}
-{% set default_npm_prefix = '/usr' %}
+  {% set default_npm_prefix = '/usr' %}
 {% endif %}
 {% set npm_prefix = pillar_get('npm:prefix', default_npm_prefix) %}
 {% set npm_bin = '{0}/bin/npm'.format(npm_prefix) %}
 {% set npm_src_requirement = 'file: {0}'.format(npm_bin) %}
 
 {% if npm_prefix == '/usr' %}
-{% set npmrc_prefix = '' %}
+  {% set npmrc_prefix = '' %}
 {% else %}
-{% set npmrc_prefix = npm_prefix %}
+  {% set npmrc_prefix = npm_prefix %}
 {% endif %}
 {% set npmrc = '{0}/etc/npmrc'.format(npmrc_prefix) %}
 
@@ -32,7 +32,16 @@
 }, grain='os', merge=pillar_get('node:lookup')) %}
 
 {% if pillar_get('node:install_from_source') or (grains['os'] == 'Debian' and grains['osrelease']|float < 8 and not pillar_get('node:install_from_ppa')) %}
-{% set npm_requirement = npm_src_requirement %}
+  {% set npm_requirement = npm_src_requirement %}
 {% else %}
-{% set npm_requirement = 'pkg: {0}'.format(node['npm_pkg']) %}
+  {% set npm_requirement = 'pkg: {0}'.format(node['npm_pkg']) %}
 {% endif %}
+
+  {% set from_src_requirements = salt['grains.filter_by']({
+  'Debian': {
+    'pkgs': ['git', 'curl', 'gcc', 'pkg-config', 'build-essential', 'checkinstall', 'libssl-dev', 'g++']
+  },
+  'RedHat': {
+    'pkgs': ['git', 'curl', 'gcc','openssl-devel','pkgconfig', 'gcc-c++', 'make', 'automake']
+  },
+}, grain='os_family', merge=pillar_get('from_src_requirements:lookup'), default='Debian') %}

--- a/node/pkg.sls
+++ b/node/pkg.sls
@@ -1,6 +1,6 @@
 {%- from "node/map.jinja" import node, npm_bin with context %}
 
-{%- if grains['os'] in ['Ubuntu', 'Debian'] and salt['pillar.get']('node:install_from_ppa') %}
+{%- if grains['os_family'] in ['Ubuntu', 'Debian'] and salt['pillar.get']('node:install_from_ppa') %}
 nodejs.ppa:
   pkg.installed:
     - name: apt-transport-https

--- a/node/source.sls
+++ b/node/source.sls
@@ -1,3 +1,5 @@
+{% from "node/map.jinja" import from_src_requirements with context %}
+
 {% set node = pillar.get('node', {}) -%}
 {% set version = node.get('version', '5.1.0') -%}
 {% set checksum = node.get('checksum', '25b2d3b7dd57fe47a483539fea240a3c6bbbdab4d89a45a812134cf1380ecb94') -%}
@@ -12,15 +14,19 @@
 
 Ensure required packages are present:
   pkg.installed:
-    - names:
-      - libssl-dev
-      - git
-      - pkg-config
-      - build-essential
-      - curl
+    - names: {{ from_src_requirements.pkgs|json }}
+
+{% if grains['os'] in ['RedHat', 'CentOS'] %}
+Alternative checkinstall requirement:
+  pkg.installed:
+    - pkgs:
+      - ruby-devel
       - gcc
-      - g++
-      - checkinstall
+
+fpm:
+  gem.installed:
+    - user: root
+{% endif %}
 
 Download node sources:
   file.managed:
@@ -48,11 +54,42 @@ make-node:
     - cwd: /usr/src/node-v{{ version }}
     - name: make --jobs={{ make_jobs }}
 
+{% if grains['os'] in ['RedHat', 'CentOS'] %}
+make-install-node:
+  cmd.run:
+    - cwd: /usr/src/node-v{{ version }}
+    - name: make install DESTDIR=/usr/src/node-v{{ version }}/tmp
+    - onchanges:
+      - cmd: make-node
+
+fpm-node:
+  cmd.run:
+    - cwd: /usr/src/node-v{{ version }}
+    - name: fpm -s dir -t rpm -C /usr/src/node-v{{ version }}/tmp --name=node --version "{{ version }}" --iteration 1 --description "Node package v{{ version }} (fpm)" --force
+    - onchanges:
+      - cmd: make-install-node
+
+install-node:
+  pkg.installed:
+    - sources:
+      - node: /usr/src/node-v{{ version }}/node-{{ version }}-1.x86_64.rpm
+    - onchanges:
+      - cmd: fpm-node
+{% else %}
+
 install-node:
   cmd.run:
     - cwd: /usr/src/node-v{{ version }}
     - name: checkinstall --install=yes --pkgname=node --pkgversion "{{ version }}" --default
     - onchanges:
       - cmd: make-node
+
+{% endif %}
+
+{% else %}
+
+Version Control:
+  test.succeed_without_changes:
+    - name: Node version {{ nodeVersion }} already installed
 
 {% endif %}

--- a/node/source.sls
+++ b/node/source.sls
@@ -16,7 +16,7 @@ Ensure required packages are present:
   pkg.installed:
     - names: {{ from_src_requirements.pkgs|json }}
 
-{% if grains['os'] in ['RedHat', 'CentOS'] %}
+{% if grains['os_family'] in ['RedHat', 'CentOS'] %}
 Alternative checkinstall requirement:
   pkg.installed:
     - pkgs:
@@ -54,7 +54,7 @@ make-node:
     - cwd: /usr/src/node-v{{ version }}
     - name: make --jobs={{ make_jobs }}
 
-{% if grains['os'] in ['RedHat', 'CentOS'] %}
+{% if grains['os_family'] in ['RedHat', 'CentOS'] %}
 make-install-node:
   cmd.run:
     - cwd: /usr/src/node-v{{ version }}


### PR DESCRIPTION
I send you a proposal to solve some problems with RedHat and CentOS.
I used gem FPM as alternative to Checkinstall.

Regards.-  
