### PR TITLE
Revert "Fix a bug with improperly used archive.extracted source value"

### DIFF
--- a/node/binary.sls
+++ b/node/binary.sls
@@ -3,11 +3,16 @@
 {% set checksum = node.get('checksum', 'f037e2734f52b9de63e6d4a4e80756477b843e6f106e0be05591a16b71ec2bd0') -%}
 {% set pkgname = 'node-v' ~ version ~ '-linux-x64' -%}
 
+Get binary package:
+  file.managed:
+    - name: /usr/local/src/{{ pkgname }}.tar.gz
+    - source: https://nodejs.org/dist/v{{ version }}/{{ pkgname }}.tar.gz
+    - source_hash: sha256={{ checksum }}
+
 Extract binary package:
   archive.extracted:
     - name: /usr/local/src/
-    - source: https://nodejs.org/dist/v{{ version }}/{{ pkgname }}.tar.gz
-    - source_hash: sha256={{ checksum }}
+    - source: /usr/local/src/{{ pkgname }}.tar.gz
     - archive_format: tar
     - if_missing: /usr/local/src/{{ pkgname }}
 


### PR DESCRIPTION
This reverts commit 48896b6efd3282ea3661b5dca6ea7580d160b51e because
with this commit, it is not possible to upgrade node.js to a newer
version. The command aborts with this error message:
cp: cannot create regular file '/usr/local/bin/node': Text file busy

See
https://github.com/saltstack-formulas/node-formula/commit/48896b6efd3282ea3661b5dca6ea7580d160b51e#commitcomment-18185563
for more information.
