### PR TITLE
Install LTS version of nodejs (6.9) by default to from PPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This formula installs [node.js](https://nodejs.org/en/).
 
+## Installing from PPA
+
+An example pillar for installing from Debian based PPA repository:
+
+    node:
+      version: 6.9.4
+      install_from_ppa: True
+      ppa:
+        repository_url: https://deb.nodesource.com/node_6.x
+
 ## Installing from source
 
 An example pillar file looks as follows:

--- a/node/pkg.sls
+++ b/node/pkg.sls
@@ -8,7 +8,7 @@ nodejs.ppa:
       - pkgrepo: nodejs.ppa
   pkgrepo.managed:
     - humanname: NodeSource Node.js Repository
-    - name: deb {{ salt['pillar.get']('node:ppa:repository_url', 'https://deb.nodesource.com/node_0.12') }} {{ grains['oscodename'] }} main
+    - name: deb {{ salt['pillar.get']('node:ppa:repository_url', 'https://deb.nodesource.com/node_6.x') }} {{ grains['oscodename'] }} main
     - dist: {{ grains['oscodename'] }}
     - file: /etc/apt/sources.list.d/nodesource.list
     - keyid: "68576280"

--- a/pillar.example
+++ b/pillar.example
@@ -13,7 +13,7 @@ node:
 
 # Install from PPA:
 node:
-  version: 5.4.0
+  version: 6.9.4
   install_from_ppa: True
   ppa:
-    repository_url: https://deb.nodesource.com/node_5.x
+    repository_url: https://deb.nodesource.com/node_6.x


### PR DESCRIPTION
Install LTS version of nodejs (`6.x`) by default to from PPA instead of no longer maintained `0.12` series.

Update readme on PPA use ( fixes #9 )