### PR TITLE
Add support for reading remote hash list

### DIFF
--- a/node/binary.sls
+++ b/node/binary.sls
@@ -20,7 +20,7 @@ Get binary package:
   file.managed:
     - name: /usr/local/src/{{ pkgname }}.tar.{{ format }}
     - source: https://nodejs.org/dist/v{{ version }}/{{ pkgname }}.tar.{{ format }}
-    - source_hash: {{ checksum }}
+    - source_hash: https://nodejs.org/dist/v{{ version }}/SHASUMS256.txt
 
 Extract binary package:
   archive.extracted:


### PR DESCRIPTION
I'm adding the actual SHA sum list here instead of the hardcoded sums. We could check both by adding them in order, but since we now support two architectures, that is probably going to break things.