### PR TITLE
Require PPA before installing nodejs

### DIFF
--- a/node/pkg.sls
+++ b/node/pkg.sls
@@ -15,7 +15,7 @@ nodejs.ppa:
     - key_url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
     - keyserver: keyserver.ubuntu.com
     - require_in:
-      pkg: node
+      - pkg: nodejs
 {%- endif %}
 nodejs:
   pkg.installed:


### PR DESCRIPTION
I fixed my salt state by changing the `require_in` to `nodejs`.

Otherwise I had times were it would try to install `nodejs` first and then setup the PPA which obviously was incorrect, but it also wasn't clear why.