### PR TITLE
Fix init.sls parsing

### DIFF
--- a/node/init.sls
+++ b/node/init.sls
@@ -1,10 +1,10 @@
 {% set pillar_get = salt['pillar.get'] -%}
 include:
-{%- if pillar_get('node:install_from_source') %}
+{% if pillar_get('node:install_from_source') %}
   - .source
-{%- elif pillar_get('node:install_from_binary') %}
+{% elif pillar_get('node:install_from_binary') %}
   - .binary
-{%- else %}
+{% else %}
   - .pkg
-{%- endif %}
+{% endif %}
   - .config


### PR DESCRIPTION
Removed few dashes from Jinja template...

Error (Salt: 2017.7.2):
```
    Data failed to compile:
----------
    Rendering SLS 'base:node' failed: sequence entries are not allowed here; line 1

---
include:  - .pkg  - .config    <======================
```