### PR TITLE
Import YAML with context

### DIFF
--- a/node/config/clean.sls
+++ b/node/config/clean.sls
@@ -24,3 +24,5 @@ node-config-clean-file-absent:
       - {{ node.environ_file }}
     - require:
       - sls: {{ sls_package_clean }}
+      
+{%- endif %}

--- a/node/map.jinja
+++ b/node/map.jinja
@@ -2,10 +2,10 @@
 # vim: ft=jinja
 
 {%- set tplroot = tpldir.split('/')[0] %}
-{%- import_yaml tplroot ~ "/defaults.yaml" as default_settings %}
-{%- import_yaml tplroot ~ "/osfamilymap.yaml" as osfamilymap %}
-{%- import_yaml tplroot ~ "/osmap.yaml" as osmap %}
-{%- import_yaml tplroot ~ "/osarchmap.yaml" as osarchmap %}
+{%- import_yaml tplroot ~ "/defaults.yaml" as default_settings with context %}
+{%- import_yaml tplroot ~ "/osfamilymap.yaml" as osfamilymap with context %}
+{%- import_yaml tplroot ~ "/osmap.yaml" as osmap with context %}
+{%- import_yaml tplroot ~ "/osarchmap.yaml" as osarchmap with context %}
 
 {%- set _config = salt['config.get'](tplroot, default={}) %}
 {%- set defaults = salt['grains.filter_by'](


### PR DESCRIPTION
Import with context to avoid errors like:

```
[CRITICAL] Rendering SLS ... failed: Jinja variable 'grains' is undefined
```

```
[CRITICAL] Rendering SLS ... failed: Jinja variable 'salt' is undefined
```